### PR TITLE
Add post-production brownbag issues to project

### DIFF
--- a/.github/workflows/assign-to-project.yml
+++ b/.github/workflows/assign-to-project.yml
@@ -34,3 +34,13 @@ jobs:
       with:
         project: 'https://github.com/Virtual-Coffee/VC-Events/projects/5'
         column_name: 'Inbox'
+    - name: "Assign issues with `Brownbag: Post-production` label to brownbag post-production project"
+      uses: srggrs/assign-one-project-github-action@1.2.0
+      if: |
+        contains(github.event.issue.labels.*.name, 'Brownbag: Post-production')
+      with:
+        project: 'https://github.com/Virtual-Coffee/VC-Events/projects/6'
+        column_name: 'Awaiting Info'
+        
+        
+        


### PR DESCRIPTION
When the `Brownbag: Post-production` label is added to an issue, the issue will get auto-added to the [Post Production project](https://github.com/Virtual-Coffee/VC-Events/projects/6)