### PR TITLE
[WIP] Adjust Notes Template

### DIFF
--- a/coffees/Notetakers/README.md
+++ b/coffees/Notetakers/README.md
@@ -4,6 +4,8 @@ Thanks for being a notetaker! We know it can be challenging to take notes and pa
 
 You will find a copy of the Notes Template below at [this link in Google Docs format](insert link here). Please make a copy of the template by navigating to 'File' and selecting 'Make a copy' which will prompt you to save the newly created copy to your own Google Drive. From there, you can rename the file and adjust the template however needed.
 
+Feel free to share your notes document with your Room Leader by clicking the 'Share' button in the top right corner and adjusting the settings to "Anyone on the internet with this link can edit." Doing this can help both you and the Room Leader keep track of the conversation and fill in notes or links that might have been missed. Some Room Leaders may choose to concentrate fully on the conversation in the breakout room and not use the notes doc. This is fine! Everyone has a unique process when faced with different tasks and our community understands and embraces that.
+
 ## Special Note
 
 - Although we assume these coffees and the contributions are covered by the "Friend-DA," we realize that there's a difference between saying something to a group of friends and having a written record. To preserve the privacy of our members and to encourage honesty and vulnerability, we ask that you **DO NOT record the names of members during the conversation portion of Virtual Coffee**, unless there's an agreement. For example, if someone says "I'm always up to pair on Elm issues," ask the member if you can reference their name in the notes so the VC community knows who they should contact.


### PR DESCRIPTION
Closes #131 

_**NOTE:** Hold on merge for discussion in coffees board and PR completion._

# Description

Rework template to streamline notetaker workflow. We can achieve this with slight changes to the content and then creating a Google Doc which can be copied for each new breakout room session.

## Content

- [ ] Add line to end of document encouraging members to continue the conversation in Slack
- [x] Change `MAIN CONVERSATION` to `TOPIC #1` and add a few more topics
- [x] Fix grammar/typos/spelling if necessary
- [ ] Create Google Doc template

## Format

Copy content of the template to a Google Doc. Allow access for anyone with the link and paste the link back into the `Notetakers/README.md` file.