### PR TITLE
Added Room leader Tip: facilitating vs participating

### DIFF
--- a/coffees/RoomLeaders-ConversationFacilitators/Tips for facilitating.md
+++ b/coffees/RoomLeaders-ConversationFacilitators/Tips for facilitating.md
@@ -7,3 +7,4 @@
 * Repeat the question or topic, and then redirect: "let's hear from someone different on this one." Or, "anyone who hasn't had a chance to speak yet have any ideas?"
 * Non-verbal signals work too! 
 * If the topic changes, use it as an opportunity to say, "I'd love to get a variety of opinions here." You can go a step further and if there are a number of hands raised, say "I'm going to prioritize calling on those who haven't had the chance to speak yet today."
+* Remember: Room Leaders are facilitators and participants. As a facilitator your purpose is to encourage others to share, and as a participant you can share as well. As a participant try to follow the same protocols as other participants, and avoid taking on the role of a "talk show host".


### PR DESCRIPTION
This is a proposed change to the room leader tips and protocol. This tip separates the role of facilitator vs participant to prevent the facilitator from over taking the conversation as a participant and compromising their role as a facilitator. 