### PR TITLE
Docs: room leader script update

### DIFF
--- a/coffees/RoomLeaders-ConversationFacilitators/README.md
+++ b/coffees/RoomLeaders-ConversationFacilitators/README.md
@@ -22,9 +22,11 @@ In order to create a safe space, we ask that our room leaders always follow the 
 We’re invested in making sure that everyone can participate in the ways they are most comfortable. That’s why it’s important to explain the hand raise function and other modes of participation.  
 
 ### Intro Script:
+Here's a template for the intention we want to communicate at the beginning of each breakout room session. Room leaders are not required to read the script verbatim, we allow for some flexibility in language so long as the major themes (freedom of expression, freedom of presentation, spirit of support and inclusivity) are mantained.
+
 Hi, I'm {your name}, and I'll be your room leader today. We have {name} as our notetaker today as well. Our notetaker will take your name down for introductions, but will leave notes for the rest of the conversation anonymous to make sure everyone is comfortable sharing. 
 
-Please feel free to participate in a way that is comfortable for you. If you want to keep your camera off, stay muted, or participate in the chat, we’ll do our best to make this a welcoming and inclusive space for everyone. We always start with introductions, so you'll say your name, and if you want: where you’re from, what you do, and then your answer to {random question}. If you’re new here, please share your first and last name in your intro and let us know so we can welcome you and get you a link to join our slack.
+Please feel free to participate in a way that is comfortable for you. If you want to keep your camera off, stay muted, or participate in the chat, we’ll do our best to make this a welcoming and inclusive space for everyone. We always start with introductions, so you'll say your name, and if you would like to share: your pronouns , where you’re from, what you do, and then your answer to {random question}.
  
 I’m going to ask everyone to start by using the handraise function, which is ALT or Option Y, or you can find it in the zoom reactions tab. Once you’ve completed your intro, you can popcorn to someone else on the screen whose hand is still raised and then put your hand down. 
  
@@ -33,7 +35,6 @@ While you're thinking about the answer to our random question, I'll go over some
 We want this to be a welcoming space and for everyone to participate in the ways that are most comfortable for them. It's perfectly acceptable to be quiet, to be more a listener, to keep your camera off.
  
 The chat is also a great place to ask questions if that's a more comfortable space.
-
  
 **Onboarding volunteer notetakers**
 - {name} is going to take notes for us today. {Pronouns} will record your intro with your name and your answer, and after that {pronouns} won't record names as part of the larger discussion to allow for open sharing.


### PR DESCRIPTION
Context for the change:

As part of keeping with our intention to be a welcoming space, we want to make it clear to members that the acknowledgement and respect of an individual's pronouns is in keeping with our standards as a community, and for those who are comfortable with sharing their pronouns, that they should feel no trepidations in doing so.

We've intentionally placed this option in the script in a way that we feel, provides both an aspect of normalisation of either saying or not saying one's pronouns, but also of hearing and respecting the pronouns of others, but also that this is no less a right to be said that any other aspect of one's individuality, and not an afterthought.

We also want to make it explicit that room leaders may have slightly different language when communicating the script but that is **okay** so long as the deviation is not major and it does not change the spirit of the original words.