### PR TITLE
Update Coffee Table Groups

### DIFF
--- a/coffee-table-groups/coffee-table-groups.md
+++ b/coffee-table-groups/coffee-table-groups.md
@@ -10,7 +10,7 @@
 ## Active Groups
 
 > [!NOTE]
-> We're continually accepting volunteer applications for Co-hosts for current Coffee Table Groups and Leads for new Coffee Table Groups.
+> We're continually accepting volunteer applications for co-hosts for current Coffee Table Groups and Leads for new Coffee Table Groups.
 >
 > Please reach out to Meg or Abbey if you have any questions.
 
@@ -24,7 +24,7 @@
 
 - Eddie Banner
 
-A weekly discussion of job search and interview-related topics, including mini mock interviews, technical topic discussions, job search tips, occasional guest speakers, and more! We are always looking for ideas to help meet your needs. All stages of career and job search welcome!
+A weekly discussion of job search and interview-related topics, including mini mock interviews, technical topic discussions, job search tips, occasional guest speakers, and more! We are always looking for ideas to help meet your needs. All stages of career and job search are welcome!
 
 Interested? Join the `#tech-interview-study-group` Slack channel!
 
@@ -44,7 +44,7 @@ Interested? Join the `#tech-interview-study-group` Slack channel!
 - **The Quad** – Rad Turkin & David Akim
 - **The Breakfast Club** – Meg Gutshall & Joe Karow
 
-You want to learn that new tool/finish up that blog post/send that job application, but you’re so busy that the day is over before you know it. Join us and add some fun and friendly accountability to your schedule!
+You want to learn that new tool, finish up that blog post, or send that job application, but you’re so busy that the day is over before you know it. Join us and add some fun and friendly accountability to your schedule!
 
 Drop into our sessions whenever and for however long your schedule allows. No matter the goal, you’ll find encouragement and support alongside your Accountabilibuddies!
 
@@ -76,7 +76,7 @@ Job hunting as a collective: An accountability session exclusively for job hunti
 
 - Eddie Banner
 
-DSA Office Hours is an opportunity to come and ask questions about anywhere you get stuck on this week’s coding problems, or about this week’s topic. Find this week’s DSA topic and coding problems in `#tech-interview-study-group`. New topic and problems every week!
+DSA Office Hours is an opportunity to come and ask questions about anywhere you get stuck on this week’s coding problems, or about this week’s topic. Find this week’s DSA topic and coding problems in `#tech-interview-study-group`. New topics and problems every week!
 
 ### Frontend Friday Folks Fighting CSSBattle.dev
 

--- a/coffee-table-groups/coffee-table-groups.md
+++ b/coffee-table-groups/coffee-table-groups.md
@@ -104,7 +104,7 @@ On Fridays, we solve a new puzzle at [CSSBattle.dev](https://cssbattle.dev/). We
 
 - Ethan Freire
 
-Feelings Friday was started at the Flatiron School coding boot camp by its founders, Avi Flombaum & Adam Enbar, after they noticed burnout among their first cohorts. Join a supportive group where everyone has the opportunity to share what’s on their mind in a safe environment. It's a great way to unwind at the end of the week!
+Feelings Friday was started at the Flatiron School coding bootcamp by its founders, Avi Flombaum & Adam Enbar, after they noticed burnout among their first cohorts. Join a supportive group where everyone has the opportunity to share what’s on their mind in a safe environment. It's a great way to unwind at the end of the week!
 
 ## Inactive Groups
 

--- a/coffee-table-groups/coffee-table-groups.md
+++ b/coffee-table-groups/coffee-table-groups.md
@@ -8,11 +8,7 @@
 ## Active Groups
 
 > [!NOTE]
-> We're looking for Co-hosts for:
->
-> - Tech Interview Study Group
-> - DSA Office Hours
-> - Frontend Friday Folks Fighting CSSBattle.dev
+> We're continually accepting volunteer applications for Co-hosts for all Coffee Table Groups.
 >
 > Please reach out to Meg or Abbey to inquire about getting involved with either of these groups.
 

--- a/coffee-table-groups/coffee-table-groups.md
+++ b/coffee-table-groups/coffee-table-groups.md
@@ -1,46 +1,47 @@
+<!-- markdownlint-disable MD024 -->
 # Coffee Table Groups
 
 > [!IMPORTANT]
-> These are the currently scheduled times for the events at the time of this publication. Please check the official Virtual Coffee `#announcements`, `#vc-events`, or other noted channels on Slack for any updates and links to event rooms.
+> These are the currently scheduled times and information for the events at the point of publication. Please check our [online events page](https://virtualcoffee.io/events) as well as the `#announcements` and `#vc-events` channels on Virtual Coffee's Slack for the latest updates and links to event rooms.
 
 ---
 
 ## Active Groups
 
 > [!NOTE]
-> We're continually accepting volunteer applications for Co-hosts for all Coffee Table Groups.
+> We're continually accepting volunteer applications for Co-hosts for current Coffee Table Groups and Leads for new Coffee Table Groups.
 >
-> Please reach out to Meg or Abbey to inquire about getting involved with either of these groups.
+> Please reach out to Meg or Abbey if you have any questions.
 
 ### Tech Interview Study Group
 
-**When:**
+#### When:
 
-- Mondays at 4:00 PM ET
+- Mondays, 4:00–5:00 PM ET
 
-**Lead & Host:**
+#### Lead & Host:
 
 - Eddie Banner
 
-A weekly discussion of job search & interview-related topics—mini mock interviews, technical topic discussions, job search tips, occasional guest speakers, etc. We are always looking for ideas to help meet your needs! All stages of career & job search are welcome.
+A weekly discussion of job search and interview-related topics, including mini mock interviews, technical topic discussions, job search tips, occasional guest speakers, and more! We are always looking for ideas to help meet your needs. All stages of career and job search welcome!
 
 Interested? Join the `#tech-interview-study-group` Slack channel!
 
 ### Accountabilibuddies
 
-**When:**
+#### When:
 
-- Tuesdays at 7:00–9:00 PM ET
-- Thursdays at 9:00–11:40 AM ET
+- **The Quad** – Tuesdays, 7:00–9:00 PM ET
+- **The Breakfast Club** – Thursdays, 9:00–11:40 AM ET
 
-**Lead:**
+#### Lead:
 
 - Meg Gutshall
 
-**Hosts:**
+#### Hosts:
 
-- **Tuesdays:** Rad Turkin & David Akim
-- **Thursdays:** Meg Gutshall & Joe Karow
+- **The Quad** – Rad Turkin & David Akim
+- **The Breakfast Club** – Meg Gutshall & Joe Karow
 
 You want to learn that new tool/finish up that blog post/send that job application, but you’re so busy that the day is over before you know it. Join us and add some fun and friendly accountability to your schedule!
 
@@ -48,62 +49,68 @@ Drop into our sessions whenever and for however long your schedule allows. No ma
 
 ### The Pack Hunt
 
-**When:**
+#### When:
 
-- Wednesdays at 10:00 AM ET
+- **Original Recipe** – Wednesdays, 10:00 AM – NOON ET
+- **Late Nite Menu** – Wednesdays, 10:00 PM – MIDNIGHT ET
 
-**Lead:**
-
-- Rad Turkin
-
-**Hosts:**
+#### Lead:
 
 - Rad Turkin
-- Derek Johnston
 
-Job Hunting as a collective—an accountability session exclusively for job hunting. Share your goals, target roles, and resources, support each other by being present, modeling good job hunting, and sharing as we apply for jobs, reach out to recruiters, and scroll LinkedIn for leads. "Hunt with the pack, arwoooo..."
+#### Hosts:
+
+- **Original Recipe** – Rad Turkin & Derek Johnston
+- **Late Nite Menu** – Lauren Collins
+
+Job hunting as a collective: An accountability session exclusively for job hunting. Support each other by being present and sharing your goals, target roles, and resources. Let's collaborate as we apply for jobs, reach out to recruiters, and scroll LinkedIn for leads. "Hunt with the pack! Arwoooo...!!!"
 
 ### Data Structures and Algorithms (DSA) Office Hours
 
-**When:**
+#### When:
 
-- Wednesdays at 4:00 PM ET
+- Wednesdays, 4:00-5:00 PM ET
 
-**Lead & Host:**
+#### Lead & Host:
 
 - Eddie Banner
 
-DSA Office Hours is an opportunity to come and ask questions about anywhere you get stuck on this week’s coding problems, or about this week’s topic. Find this week’s DSA topic and coding problems in #tech-interview-study-group. New topic and problems every week!
-
-### Feelings Friday
-
-**When:**
-
-- Fridays at 8:00 PM ET
-
-**Lead & Host:**
-
-- Ethan Freire
-
-Feelings Friday was started at the Flatiron School coding bootcamp by its founders, Avi Flombaum & Adam Enbar, after noticing burnout among their first cohorts. Join a safe space to share what that's on your mind and hold space for others. It's a great way to unwind at the end of the week!
+DSA Office Hours is an opportunity to come and ask questions about anywhere you get stuck on this week’s coding problems, or about this week’s topic. Find this week’s DSA topic and coding problems in `#tech-interview-study-group`. New topic and problems every week!
 
 ### Frontend Friday Folks Fighting CSSBattle.dev
 
-**When:**
+#### When:
 
-- Every other Friday at 11:00 AM ET
+- Fridays, 11:00 AM – NOON ET
 
-**Lead & Host:**
+#### Lead:
 
 - Jörn Bernhardt
 
-Every other Friday, we solve a new puzzle at [CSSBattle.dev](https://cssbattle.dev/). We meet in the #co-working-room for this Coffee Table, and can move our meeting to a breakout room so as not to disturb any co-working VC members. Feel free to join us and learn more about CSS! If you can't make it, be sure to play along on your own and post your answers in [Virtual Coffee's CSS Battles Discussion board](https://github.com/orgs/Virtual-Coffee/discussions/categories/css-battles)!
+#### Hosts:
+
+- Jörn Bernhardt
+- Micha Rodriguez
+
+On Fridays, we solve a new puzzle at [CSSBattle.dev](https://cssbattle.dev/). We meet in the `#co-working-room` for this Coffee Table Group, and can move our meeting to a breakout room so as not to disturb any co-working VC members. Feel free to join us and learn more about CSS! If you can't make it, be sure to play along on your own and post your answers in [Virtual Coffee's CSS Battles Discussion board](https://github.com/orgs/Virtual-Coffee/discussions/categories/css-battles)!
+
+### Feelings Friday
+
+#### When:
+
+- Fridays, 8:00–9:00 PM ET
+
+#### Lead & Host:
+
+- Ethan Freire
+
+Feelings Friday was started at the Flatiron School coding boot camp by its founders, Avi Flombaum & Adam Enbar, after they noticed burnout among their first cohorts. Join a supportive group where everyone has the opportunity to share what’s on their mind in a safe environment. It's a great way to unwind at the end of the week!
 
 ## Inactive Groups
 
 ### Virtual Coffee Book Club
 
-**Previous Leads:**
+#### Previous Leads:
 
 - Savannah Acevedo
 - Lauren C
@@ -119,7 +126,7 @@ Just join the `#book-club` Slack channel!
 
 ### The Rust Learning Cohort
 
-**Previous Leads:**
+#### Previous Leads:
 
 - Andy E
 - Meg Gutshall
@@ -127,26 +134,26 @@ Just join the `#book-club` Slack channel!
 
 ### Public Speaking Practice Group
 
-**Previous Lead & Host:**
+#### Previous Lead & Host:
 
 - Ray Deck
 
 ### TypeScript Tuesdays
 
-**Previous Leads & Hosts:**
+#### Previous Leads & Hosts:
 
 - Dan Ott
 - Kirk Shillingford
 
 ### The JavaScript Meetup
 
-**Previous Lead & Host:**
+#### Previous Lead & Host:
 
 - Travis Martin
 
 ### Indie-Startup Hackers
 
-**Previous Lead & Host:**
+#### Previous Lead & Host:
 
 - Ray Deck
 

--- a/coffee-table-groups/coffee-table-groups.md
+++ b/coffee-table-groups/coffee-table-groups.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD024 -->
+
 # Coffee Table Groups
 
 > [!IMPORTANT]

--- a/coffee-table-groups/guides/guide-to-accountabilibuddies.md
+++ b/coffee-table-groups/guides/guide-to-accountabilibuddies.md
@@ -38,17 +38,33 @@ Be sure to arrive to the meeting on time. If you can't make a meeting, or you'll
 
 Each Accountabilibuddies group has different regulars and a different vibe. When deciding an itinerary for Accountabilibuddies, we've found it's best to feel out the group and structure it around what works for the natural flow of that particular group.
 
-### Tuesday Meeting
+### The Quad (Tuesday Meeting)
 
-TBD
+The Hosts should be sure to get into the Zoom room a minute or two early so they have enough time to set up the breakout rooms before the event begins. For this iteration of Accountabilibuddies, having a dedicated Pomodoro breakout room is a must.
 
-### Thursday Meeting
+#### 7:00–7:30 PM ET
 
-#### 9:00 - 9:45/10:00 AM ET
+First Pomodoro session – 25 minutes, 5 minute break
+
+#### 7:30–8:00 PM ET
+
+Second Pomodoro session – 25 minutes, 5 minute break
+
+#### 8:00–8:30 PM ET
+
+Third Pomodoro session – 25 minutes, 5 minute break
+
+#### 8:30–9:00 PM ET
+
+Last Pomodoro session – 25 minutes, 5 minute break
+
+### The Breakfast Club (Thursday Meeting)
+
+#### 9:00-9:45/10:00 AM ET
 
 This time is akin to our random chatter before Virtual Coffee announcements. People (read: Meg) are still waking up and getting to their computers. By the first half hour, we usually have a good group online so we get some chit-chat in before settling down.
 
-#### 10:00 – 11:40 AM ET
+#### 10:00–11:40 AM ET
 
 We've decided that 10:00 AM is our "buckle down" time and any chatter after that should be focused on helping each other with the tasks at hand. This period is treated much like the `#co-working-room` atmosphere. We're all mainly concentrated on our various tasks. Someone will break the silence occasionally and we chat for a few minutes, but then we get back into the workflow.
 

--- a/coffee-table-groups/guides/guide-to-hosting-a-coffee-table-group.md
+++ b/coffee-table-groups/guides/guide-to-hosting-a-coffee-table-group.md
@@ -55,7 +55,7 @@ Once your Co-host enters the Zoom, hover over their name in the Participants tab
 
 ### Creating Breakout Rooms
 
-Some Coffee Table groups utilize breakout rooms. If yours is one of those groups, read on to learn how to create breakout rooms.
+Some Coffee Table Groups utilize breakout rooms. If yours is one of those groups, read on to learn how to create breakout rooms.
 
 Once you claim Host in Zoom, you'll see a 'Breakout rooms' tab. When you select this, a pop-up will appear with options. Be sure to select the following:
 

--- a/coffee-table-groups/guides/guide-to-the-pack-hunt.md
+++ b/coffee-table-groups/guides/guide-to-the-pack-hunt.md
@@ -1,0 +1,9 @@
+# Guide to The Pack Hunt
+
+## History
+
+<!-- Include a history of how the group started if you'd like -->
+
+## Host Duties
+
+<!-- What is required of the host to successfully run a Pack Hunt meeting? Include a script, links, resources, etc. here. -->

--- a/monthly-challenges/month-of-learning/archive/month-of-learning.md
+++ b/monthly-challenges/month-of-learning/archive/month-of-learning.md
@@ -4,10 +4,10 @@
 
 ### Pre-work
 
-- Announce new challenge mid-early Decemeber to get people thinking about the challenge
+- Announce new challenge mid-early December to get people thinking about the challenge
 - The last week of the month announce in VC
 - Get the challenge page up
-- Talk to the coffee table groups
+- Talk to the Coffee Table Groups
 
 ### During the challenge
 


### PR DESCRIPTION
## Linked Issue

Closes #452 

## Description & Methodology

- Link to the site's Events page for the latest information
- Reword callout to ask for volunteers for Coffee Table Groups
  - Open call for Co-hosts for current CTGs and Leads for new CTGs
- Add new Pack Hunt session info
- Add new CSSBattle Co-host info
- Spruce up CTG descriptions
  - Add Accountabilibuddies and Pack Hunt tracks
- Update **Guide to Accountabilibuddies** file
- Add **Guide to The Pack Hunt** file outline
- Capitalize term `Coffee Table Groups` throughout repo for consistency

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
