### PR TITLE
docs: Add guide for Pack Hunt

### DIFF
--- a/docs/coffee-table-groups/guides/guide-to-the-pack-hunt.md
+++ b/docs/coffee-table-groups/guides/guide-to-the-pack-hunt.md
@@ -31,10 +31,124 @@ tags:
   - 'coffee table groups'
 ---
 
-## History
+## Pack Hunt Activities
 
-<!-- Include a history of how the group started if you'd like -->
+In general, material building (cover letters, portfolios, resumes, etc.) and related intensive job hunt support should be directed toward Monday’s Tech Interview Study Group (#tech-interview-study-group), but short reviews, questions, and support will always be allowed in The Pack Hunt if other attendees have the bandwidth to help.
 
 ## Host Duties
 
-<!-- What is required of the host to successfully run a Pack Hunt meeting? Include a script, links, resources, etc. here. -->
+Be sure to read through the [Guide to Hosting a Coffee Table Group](guide-to-hosting-a-coffee-table-group.md) documentation to gain an understanding of what is expected of you as a Coffee Table Host.
+
+Read on for additional info specific to Pack Hunt Hosts.
+
+### Greeting Attendees
+
+Remember to share [the dedicated Pomodoro timer link](#resources) in the Zoom's group chat during the **Check-ins & Goals** portion of the session so other attendees can join.
+
+It is recommended that all participants mute their microphones during each Pomodoro session as to disturb others. If anyone joins during one of the Pomodoro sessions, greet them via the Zoom chat and re-paste the Pomodoro timer link so they can join the group with as little disruption as possible.
+
+## Itinerary
+
+### Hour 1
+
+<table>
+  <tr>
+    <th>Time</th>
+    <th>Activity</th>
+    <th>Duration</th>
+  </tr>
+  <tr>
+    <td>:00</td>
+    <td>
+      <p>Check-ins & Goals</p>
+      <ul>
+        <li>Name, location, pronouns</li>
+        <li>How is the job hunt going? Any highs/lows?</li>
+        <li>What are your goals for today?</li>
+      </ul>
+      <b>WOLFPACK HOWL!</b>
+    </td>
+    <td>< 4 minutes each</td>
+  </tr>
+  <tr>
+    <td>:20</td>
+    <td>First Pomodoro Session</td>
+    <td>25 minutes</td>
+  </tr>
+  <tr>
+    <td>:45</td>
+    <td>
+      <p>Break Time!</p>
+      <ul>
+        <li>Stand up and stretch</li>
+        <li>Get a drink or snack</li>
+        <li>Report any progress or accomplished goals</li>
+      </ul>
+    </td>
+    <td>5 minutes</td>
+  </tr>
+  <tr>
+    <td>:50</td>
+    <td>Second Pomodoro Session</td>
+    <td>25 minutes</td>
+  </tr>
+</table>
+
+### Hour 2
+
+<table>
+  <tr>
+    <th>Time</th>
+    <th>Activity</th>
+    <th>Duration</th>
+  </tr>
+  <tr>
+    <td>:15</td>
+    <td>
+      <p>Break Time!</p>
+      <ul>
+        <li>Stand up and stretch</li>
+        <li>Get a drink or snack</li>
+        <li>Report any progress or accomplished goals</li>
+      </ul>
+    </td>
+    <td>10 minutes</td>
+  </tr>
+  <tr>
+    <td>:25</td>
+    <td>
+      <p>Choice of:</p>
+      <ul>
+        <li>Third Pomodoro Session</li>
+        <li>Resource Swap and Support Session</li>
+      </ul>
+    </td>
+    <td>25 minutes</td>
+  </tr>
+  <tr>
+    <td>:50</td>
+    <td>
+      <p>Check-outs</p>
+      <ul>
+        <li>How are you feeling?</li>
+        <li>How many jobs did you apply to?</li>
+        <li>How many of your goals did you accomplish?</li>
+      </ul>
+    </td>
+    <td>10 minutes</td>
+  </tr>
+</table>
+
+## Wrap Up
+
+At the conclusion of each session, post stats in the `#pack-hunt` Slack channel as follows:
+
+- total wolves: → Number of attendees
+- total kills: → Number of jobs secured
+- jobs applied: → Number of applications completed
+- goals achieved: → Number of goals completed
+- One `:werewolf:` Slackmoji for each attendee
+
+## Resources
+
+Pomodoro Timer: [https://cuckoo.team/packhunt](https://cuckoo.team/packhunt)


### PR DESCRIPTION
## Linked Issue

Closes #430 

## Description

Add content to the **Guide to Pack Hunt** file, drawing upon the Canvas in the `#pack-hunt` Slack channel.

## Methodology

This addition is part of an effort to document the procedures behind all of our Coffee Table events. This will give more transparency to the processes, in hopes of making members feel more confident in volunteering to host and/or lead these types of events.

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
