### PR TITLE
509 docs remove eddie from accountabilibuddies hosts and remove dsa office hours ctg

### DIFF
--- a/docs/coffee-table-groups/coffee-table-groups-list.md
+++ b/docs/coffee-table-groups/coffee-table-groups-list.md
@@ -86,18 +86,6 @@ Drop into our sessions whenever and for however long your schedule allows. No ma
 
 Job hunting as a collective: An accountability session exclusively for job hunting. Support each other by being present and sharing your goals, target roles, and resources. Let's collaborate as we apply for jobs, reach out to recruiters, and scroll LinkedIn for leads. "Hunt with the pack! Arwoooo...!!!"
 
-### Data Structures and Algorithms (DSA) Office Hours
-
-#### When:
-
-- Wednesdays, 4:00-4:30 PM ET
-
-#### Lead & Host:
-
-- Eddie Banner
-
-DSA Office Hours is an opportunity to come and ask questions about anywhere you get stuck on this week’s coding problems, or about this week’s topic. Find this week’s DSA topic and coding problems in `#tech-interview-study-group`. New topics and problems every week!
-
 ### Frontend Friday Folks Fighting CSSBattle.dev
 
 #### When:
@@ -141,6 +129,14 @@ Feelings Friday was started at the Flatiron School coding bootcamp by its founde
 A weekly discussion of job search and interview-related topics, including mini mock interviews, technical topic discussions, job search tips, occasional guest speakers, and more! We are always looking for ideas to help meet your needs. All stages of career and job search are welcome!
 
 Interested? Join the `#tech-interview-study-group` Slack channel!
+
+### Data Structures and Algorithms (DSA) Office Hours
+
+#### Previous Lead & Host:
+
+- Eddie Banner
+
+DSA Office Hours is an opportunity to come and ask questions about anywhere you get stuck on this week’s coding problems, or about this week’s topic. Find this week’s DSA topic and coding problems in `#tech-interview-study-group`. New topics and problems every week!
 
 ### Virtual Coffee Book Club
 

--- a/docs/coffee-table-groups/coffee-table-groups-list.md
+++ b/docs/coffee-table-groups/coffee-table-groups-list.md
@@ -67,7 +67,7 @@ Below are the currently scheduled times and information for the events at the po
 
 #### Hosts:
 
-- **Jump Start** – Rad Turkin & Eddie Banner
+- **Jump Start** – Rad Turkin
 - **The Breakfast Club** – Meg Gutshall & Joe Karow
 
 You want to learn that new tool, finish up that blog post, or send that job application, but you’re so busy that the day is over before you know it. Join us and add some fun and friendly accountability to your schedule!

--- a/docs/coffee-table-groups/guides/guide-to-accountabilibuddies.md
+++ b/docs/coffee-table-groups/guides/guide-to-accountabilibuddies.md
@@ -83,9 +83,8 @@ Share your progress from the previous week, outline plans for the upcoming week,
 
 Choose your path:
 
-- Join optional Pomodoro sessions in breakout rooms for focused work time
-- Participate in discussion-based sessions for advice and problem-solving
-- Access breakout rooms for mock interviewing, resume review, or other collaborative work
+- Join Pomodoro session for focused work time
+- Access breakout rooms for advice, problem-solving, and other collaborative work
 
 ### The Breakfast Club (Thursday Meeting)
 


### PR DESCRIPTION
## Linked Issue

Closes #509 

## Description

Removes Eddie as Accountabilibuddies Host and removes DSA Office Hours CTG from active list

## Code of Conduct

> By submitting this pull request, you agree to follow our [Code of Conduct](https://virtualcoffee.io/code-of-conduct/)
